### PR TITLE
Fix for rules within media queries (plus overall cleanup and documentation)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,9 @@
+2014.12.09, Version 0.0.2 (Unstable)
+
+* Implemented fix to parse style rules within media queries
+* Moved from `base_path` configuration param to an `options` object (backward-compatible)
+* Refactored main method as multiple smaller functions
+* Refactored function expressions as declarations for more informative stacktraces
+* Lint cleanup
+* Added JSDoc comments
+* Updated contributors

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
-//var autoprefixer = require('autoprefixer');
+'use strict';
 
+//var autoprefixer = require('autoprefixer');
 var rework = require('rework');
 var svg = require('./svg');
 
 module.exports = function () {
-    var args = Array.prototype.slice.call(arguments);
+  var args = Array.prototype.slice.call(arguments);
 
-    return function (style) {
-        this.on('end', function (err, css) {
-            var cssObj = rework(css);
-            cssObj.use(svg());
-			
-			return cssObj.toString();
-        });
-    }
+  return function (style) {
+    this.on('end', function (err, css) {
+      var cssObj = rework(css);
+      cssObj.use(svg(args));
 
-}
+      return cssObj.toString();
+    });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
   "name": "svg-stylus",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "This project aims to recreate the functionality of rework-svg but adapted to work with Stylus.",
   "license": "MIT",
   "author": {
     "name": "Eric Wallmander",
     "url": "http://wallmander.net/"
   },
-  "contributors": [{
-    "name": "Reine Schellin",
-    "email": "reine@wallmanderco.se"
-  }],
+  "contributors": [
+    {
+      "name": "Reine Schellin",
+      "email": "reine@wallmanderco.se"
+    },
+    {
+      "name": "Phil Gold",
+      "email": "pgold@rubixmedia.com"
+    }
+  ],
   "keywords": [
     "svg",
     "stylus",
@@ -20,10 +26,10 @@
     "encode",
     "github"
   ],
-  "homepage": "https://github.com/walle89/svg-stylus/",
+  "homepage": "https://github.com/pgoldrbx/svg-stylus/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/walle89/svg-stylus.git"
+    "url": "https://github.com/pgoldrbx/svg-stylus.git"
   },
   "main": "index.js",
   "engines": {
@@ -31,10 +37,17 @@
   },
   "dependencies": {
     "rework": "*",
-	"underscore": "*",
+    "underscore": "*",
     "xmldoc": "git://github.com/jankuca/xmldoc.git"
   },
   "bugs": {
     "url": "https://github.com/walle89/svg-stylus/issues/"
-  }
+  },
+  "gitHead": "e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62",
+  "readme": "#SVG Stylus\n\nThis project aims to recreate the functionality of [rework-svg](https://npmjs.org/package/rework-svg) but adapted to work with [Stylus](http://learnboost.github.io/stylus/).\n\n##Installation\n\n###Node installation\n```bash\n$ npm install -g svg-stylus\n```\n###Node installation (master from Github)\n```bash\n$ npm install -g https://github.com/walle89/svg-stylus/archive/master.tar.gz\n```\n##Usage\n\n###Run the plugin from the command line\n```bash\n$ stylus -u svg-stylus\n```\n###Important notes\nGiven the difference in syntax between CSS and Stylus, some adaptions to syntax have been made.\nAvailable characters which do not yield Stylus syntax errors are fairly few and thus syntax is more limited than in rework-svg.\n\nurl() has been replaced with svgurl() as url() will automatically be base64 encoded.\nThe URL inside svgurl() MUST be surrounded by quotes or Stylus will yield a syntax error.\n\nSVG parameters are given as:\n\n```css\nsvg([selector attribute value [, selector attribute value...]])\n```\n\nThis means selector must be repeated to set multiple attributes.\n\n###Selectors\n\n* tagname\n* tagname#id -> entered as tagname$id, as # yields Stylus syntax error.\n* tagname[attr=\"value\"] -> *Not supported*. [] yields Stylus syntax error.\n* tagname#id[attr=\"value\"] -> *Not supported*. # and [] yields Stylus syntax errors.\n\n###Examples\n\n####SVG file inlined (rework-svg)\n\n```css\nbackground-image: url('./img/icon.svg') svg();\n```\n\n####SVG file inlined (svg-stylus)\n\n```css\nbackground-image svgurl('./img/icon.svg') svg()\n```\n\n---\n\n####All paths filled red (rework-svg)\n```css\nbackground-image: url('./img/icon.svg') svg({\npath { fill: #FF0000; }\n});\n```\n\n####All paths filled red (svg-stylus)\n\n```css\nbackground-image svgurl('./img/icon.svg') svg(path fill #FF0000)\n```\n\n---\n\n####First path filled green, second filled red (rework-svg)\n```css\nbackground-image: url('./img/icon.svg') svg({\n\tpath#p1 { fill: #00FF00; }\n\tpath[id=\"p2\"] { fill: #FF0000; }\n});\n```\n\n####First path filled green, second filled red (svg-stylus)\n```css\nbackground-image: svgurl('./img/icon.svg') svg(path$p1 fill #00FF00, path$p2 fill #FF0000)\n```\n\n##Feedback, issues, bugs, etc.\nCreate a issue at SVG Stylus [Github page](https://github.com/walle89/svg-stylus/issues).\n\n##License (MIT)\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
+  "readmeFilename": "README.md",
+  "_id": "svg-stylus@0.0.1",
+  "_shasum": "dedd5323e8edb4fb8c9ec7d682e3fc171d96ffe1",
+  "_from": "../../../../../var/folders/kx/z37vckxx68g63lytvwqp7q140000gn/T/npm-12801-02a2f6a3/1418504562934-0.5456485711038113/e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62",
+  "_resolved": "git://github.com/pgoldrbx/svg-stylus#e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62"
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "encode",
     "github"
   ],
-  "homepage": "https://github.com/pgoldrbx/svg-stylus/",
+  "homepage": "https://github.com/walle89/svg-stylus/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pgoldrbx/svg-stylus.git"
+    "url": "https://github.com/walle89/svg-stylus.git"
   },
   "main": "index.js",
   "engines": {
@@ -42,12 +42,5 @@
   },
   "bugs": {
     "url": "https://github.com/walle89/svg-stylus/issues/"
-  },
-  "gitHead": "e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62",
-  "readme": "#SVG Stylus\n\nThis project aims to recreate the functionality of [rework-svg](https://npmjs.org/package/rework-svg) but adapted to work with [Stylus](http://learnboost.github.io/stylus/).\n\n##Installation\n\n###Node installation\n```bash\n$ npm install -g svg-stylus\n```\n###Node installation (master from Github)\n```bash\n$ npm install -g https://github.com/walle89/svg-stylus/archive/master.tar.gz\n```\n##Usage\n\n###Run the plugin from the command line\n```bash\n$ stylus -u svg-stylus\n```\n###Important notes\nGiven the difference in syntax between CSS and Stylus, some adaptions to syntax have been made.\nAvailable characters which do not yield Stylus syntax errors are fairly few and thus syntax is more limited than in rework-svg.\n\nurl() has been replaced with svgurl() as url() will automatically be base64 encoded.\nThe URL inside svgurl() MUST be surrounded by quotes or Stylus will yield a syntax error.\n\nSVG parameters are given as:\n\n```css\nsvg([selector attribute value [, selector attribute value...]])\n```\n\nThis means selector must be repeated to set multiple attributes.\n\n###Selectors\n\n* tagname\n* tagname#id -> entered as tagname$id, as # yields Stylus syntax error.\n* tagname[attr=\"value\"] -> *Not supported*. [] yields Stylus syntax error.\n* tagname#id[attr=\"value\"] -> *Not supported*. # and [] yields Stylus syntax errors.\n\n###Examples\n\n####SVG file inlined (rework-svg)\n\n```css\nbackground-image: url('./img/icon.svg') svg();\n```\n\n####SVG file inlined (svg-stylus)\n\n```css\nbackground-image svgurl('./img/icon.svg') svg()\n```\n\n---\n\n####All paths filled red (rework-svg)\n```css\nbackground-image: url('./img/icon.svg') svg({\npath { fill: #FF0000; }\n});\n```\n\n####All paths filled red (svg-stylus)\n\n```css\nbackground-image svgurl('./img/icon.svg') svg(path fill #FF0000)\n```\n\n---\n\n####First path filled green, second filled red (rework-svg)\n```css\nbackground-image: url('./img/icon.svg') svg({\n\tpath#p1 { fill: #00FF00; }\n\tpath[id=\"p2\"] { fill: #FF0000; }\n});\n```\n\n####First path filled green, second filled red (svg-stylus)\n```css\nbackground-image: svgurl('./img/icon.svg') svg(path$p1 fill #00FF00, path$p2 fill #FF0000)\n```\n\n##Feedback, issues, bugs, etc.\nCreate a issue at SVG Stylus [Github page](https://github.com/walle89/svg-stylus/issues).\n\n##License (MIT)\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
-  "readmeFilename": "README.md",
-  "_id": "svg-stylus@0.0.1",
-  "_shasum": "dedd5323e8edb4fb8c9ec7d682e3fc171d96ffe1",
-  "_from": "../../../../../var/folders/kx/z37vckxx68g63lytvwqp7q140000gn/T/npm-12801-02a2f6a3/1418504562934-0.5456485711038113/e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62",
-  "_resolved": "git://github.com/pgoldrbx/svg-stylus#e1c247dd3ea0b3bcd0835e35ca33c7cb4958ee62"
+  }
 }

--- a/svg.js
+++ b/svg.js
@@ -1,4 +1,3 @@
-/*jslint vars:true*/
 'use strict';
 
 var _ = require('underscore');
@@ -19,6 +18,7 @@ var SVG_PATTERN = new RegExp(
     '(?:(.*?))?' + '\\s*' +
     '\\))'
 );
+
 
 var SELECTOR_PATTERN = new RegExp(
   '^' +
@@ -160,10 +160,10 @@ function getSvgPropAsJSON(style) {
 /**
  * Replace style declaration value
  * String.replace() method
- * @param match {?} ?
- * @param match {String} ?
- * @param match {String} ?
- * @param match {?} ?
+ * @param match {String} match Matched substring
+ * @param match {String} pre_whitespace Original whitespace
+ * @param match {String} url_match url(...)
+ * @param match {String} svg_style_json SVG style information
  * @returns {String} new declaration value
  */
 function replaceDeclarationValue(match, pre_whitespace, url_match, svg_style_json) {
@@ -184,10 +184,10 @@ function replaceDeclarationValue(match, pre_whitespace, url_match, svg_style_jso
  * @returns {undefined} undefined
  */
 function parseDeclaration(declaration) {
+  // TODO : allow `background` properties
   if (!declaration || declaration.property !== 'background-image') {
     return;
   }
-
   declaration.value = declaration.value.replace(SVG_PATTERN, replaceDeclarationValue);
 }
 
@@ -198,10 +198,12 @@ function parseDeclaration(declaration) {
  * @returns {undefined} undefined
  */
 function parseRule(rule) {
-  if (!rule || !rule.declarations) {
-    return;
+  if (rule.declarations) {
+    rule.declarations.forEach(parseDeclaration);
+  } else if (rule.rules) {
+    // nested rules, e.g. media query block
+    rule.rules.forEach(parseRule);
   }
-  rule.declarations.forEach(parseDeclaration);
 }
 
 

--- a/svg.js
+++ b/svg.js
@@ -1,42 +1,65 @@
+/*jslint vars:true*/
+'use strict';
+
 var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
 var rework = require('rework');
 var xmldoc = require('xmldoc');
+var _config = {};
 
 
 var SVG_PATTERN = new RegExp(
   '(^|\\s)' +
-  // url(...)
-  '(?:svgurl\\((.*?)\\))' + '\\s+' +
-  // svg(...)
-  '(?:svg\\(' + '\\s*' +
+    // url(...)
+    '(?:svgurl\\((.*?)\\))' + '\\s+' +
+    // svg(...)
+    '(?:svg\\(' + '\\s*' +
     // { ... } (optional)
     '(?:(.*?))?' + '\\s*' +
-  '\\))'
+    '\\))'
 );
 
 var SELECTOR_PATTERN = new RegExp(
   '^' +
-  // tag name
-  '([\\w:-]+)' +
-  // ID (optional)
-  '(?:#([\\w:-]+))?' +
-  // attribute (optional)
-  '(?:\\[' +
+    // tag name
+    '([\\w:-]+)' +
+    // ID (optional)
+    '(?:#([\\w:-]+))?' +
+    // attribute (optional)
+    '(?:\\[' +
     // attribute name
     '([\\w:-]+)' +
     // attribute value (optional)
     '(?:=([^\\]]+))?' +
-  '\\])?' +
-  '$'
+    '\\])?' +
+    '$'
 );
 
 
-var getStyledSvgAsDataURL = function (filename, style) {
+/**
+ * Parse config options
+ * @param {Object|String} options Options map; falls back to support original `base_path` param
+ * @returns {undefined} undefined
+ */
+function parseConfig(options) {
+  if (typeof options === 'object') {
+    _config = _.extend(_config, options);
+  } else if (typeof options === 'string') {
+    _config.base_path = options;
+  }
+}
+
+
+/**
+ * Get SVG as ecoded data
+ * @returns {String} encoded image data
+ */
+function getStyledSvgAsDataURL(filename, style) {
   var xml_source = fs.readFileSync(filename, 'utf8');
   var doc = new xmldoc.XmlDocument(xml_source);
 
+  // Populate all SVG styles
   style.rules.forEach(function (rule) {
     if (rule.declarations) {
       rule.selectors.forEach(function (selector) {
@@ -53,10 +76,16 @@ var getStyledSvgAsDataURL = function (filename, style) {
 
   var svg_buffer = new Buffer(doc.toString(true, true));
   return 'data:image/svg+xml;base64,' + svg_buffer.toString('base64');
-};
+}
 
 
-var querySelectorAll = function (root, selector) {
+/**
+ * Get document elements
+ * @param {Object} root Root element
+ * @param {String} selector Element selector
+ * @returns {Array} matched elements
+ */
+function querySelectorAll(root, selector) {
   var selector_path = selector.split(/\s+/);
   var elements = [ root ];
 
@@ -70,9 +99,11 @@ var querySelectorAll = function (root, selector) {
       return el.childrenNamedRecursive(level_parts[1]);
     }));
 
+    var attr_matches;
+
     // children by ID
     if (level_parts[2]) {
-      var attr_matches = _.union.apply(_, elements.map(function (el) {
+      attr_matches = _.union.apply(_, elements.map(function (el) {
         var value = (level_parts[2] || '').replace(/^["']|["']$/g, '');
         return el.childrenWithAttributeRecursive('id', value);
       }));
@@ -82,7 +113,7 @@ var querySelectorAll = function (root, selector) {
 
     // children by attribute
     if (level_parts[3]) {
-      var attr_matches = _.union.apply(_, elements.map(function (el) {
+      attr_matches = _.union.apply(_, elements.map(function (el) {
         var value = (level_parts[4] || '').replace(/^["']|["']$/g, '');
         return el.childrenWithAttributeRecursive(level_parts[4], value);
       }));
@@ -96,45 +127,100 @@ var querySelectorAll = function (root, selector) {
   }
 
   return elements;
-};
-
-var getSvgPropAsJSON = function(style) {
-	if (!style)
-		return '';
-	
-	var json = '';
-
-	var rules = style.split(',');
-	for (var i=0;i<rules.length;i++) {
-		var parts = rules[i].trim().split(/\s+/);
-		if (parts.length < 3)
-			continue;
-		
-		json += parts[0].replace(/\$/g,'#')+'{'+parts[1]+':'+parts[2]+'} ';
-	}
-	
-	return json;
 }
 
-module.exports = function (base_path) {
-  return function (style) {
-    style.rules.forEach(function (rule) {
-      if (rule.declarations) {
-        rule.declarations.forEach(function (declaration) {
-          if (declaration.property === 'background-image') {
-            declaration.value = declaration.value.replace(SVG_PATTERN,
-                function (match, pre_whitespace, url_match, svg_style_json) {
-              var url = url_match.replace(/^["']|["']$/g, '');
-              // rewrite param syntax to rework-svg JSON before rework
-			  var svg_style = rework(getSvgPropAsJSON(svg_style_json)).obj.stylesheet;
-              var filename = base_path ? path.join(base_path, url) : url;
 
-              var svg_data_uri = getStyledSvgAsDataURL(filename, svg_style);
-              return pre_whitespace + 'url(\'' + svg_data_uri + '\')';
-            });
-          }
-        });
-      }
-    });
-  };
+/**
+ * Get SVG property as JSON
+ * @param {String} style Style property
+ * @returns {String} json string
+ */
+function getSvgPropAsJSON(style) {
+  var json = '';
+
+  if (!style) {
+    return json;
+  }
+
+  var rules = style.split(',');
+  var i, len;
+  for (i = 0, len = rules.length; i < len; i++) {
+    var parts = rules[i].trim().split(/\s+/);
+    if (parts.length < 3) {
+      continue;
+    }
+
+    json += parts[0].replace(/\$/g, '#') + '{' + parts[1] + ':' + parts[2] + '} ';
+  }
+
+  return json;
+}
+
+
+/**
+ * Replace style declaration value
+ * String.replace() method
+ * @param match {?} ?
+ * @param match {String} ?
+ * @param match {String} ?
+ * @param match {?} ?
+ * @returns {String} new declaration value
+ */
+function replaceDeclarationValue(match, pre_whitespace, url_match, svg_style_json) {
+  var url = url_match.replace(/^["']|["']$/g, '');
+
+  // rewrite param syntax to rework-svg JSON before rework
+  var svg_style = rework(getSvgPropAsJSON(svg_style_json)).obj.stylesheet;
+  var filename = _config.base_path ? path.join(_config.base_path, url) : url;
+
+  var svg_data_uri = getStyledSvgAsDataURL(filename, svg_style);
+  return pre_whitespace + 'url(\'' + svg_data_uri + '\')';
+}
+
+
+/**
+ * Parse style declaration
+ * @param {Object} declaration Style declaration
+ * @returns {undefined} undefined
+ */
+function parseDeclaration(declaration) {
+  if (!declaration || declaration.property !== 'background-image') {
+    return;
+  }
+
+  declaration.value = declaration.value.replace(SVG_PATTERN, replaceDeclarationValue);
+}
+
+
+/**
+ * Parse style rule
+ * @param {Object} rule Style rule
+ * @returns {undefined} undefined
+ */
+function parseRule(rule) {
+  if (!rule || !rule.declarations) {
+    return;
+  }
+  rule.declarations.forEach(parseDeclaration);
+}
+
+
+/**
+ * Process styles
+ * @param {Object} style Style object
+ * @returns {undefined} undefined
+ */
+function svgStylus(style) {
+  if (!style || !style.rules) {
+    return;
+  }
+  style.rules.forEach(parseRule);
+}
+
+
+
+// Configure and export
+module.exports = function (options) {
+  parseConfig(options);
+  return svgStylus;
 };


### PR DESCRIPTION
* Implemented fix to parse style rules within media queries
* Moved from `base_path` configuration param to an `options` object (backward-compatible)
* Refactored main method as multiple smaller functions
* Refactored function expressions as declarations for more informative stacktraces
* Lint cleanup
* Added JSDoc comments
* Updated contributors
* Version bump