### PR TITLE
Support passing base64 encoded SVG instead of file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ background-image: url('./img/icon.svg') svg({
 background-image: svgurl('./img/icon.svg') svg(path$p1 fill #00FF00, path$p2 fill #FF0000)
 ```
 
+---
+
+#### Resolving a relative path
+
+The Stylus built-in function `embedurl()` can be used to resolve a relative URL (taking into account Stylus' `options.paths` as well) and pass the SVG data directly to `svg-stylus`:
+
+```css
+background-image svgurl(embedurl('img/icon.svg')) svg(path fill #FF0000)
+```
+
 ##Feedback, issues, bugs, etc.
 Create a issue at SVG Stylus [Github page](https://github.com/walle89/svg-stylus/issues).
 


### PR DESCRIPTION
It's currently not possible to resolve paths inside of a Stylus plugin, and we can't achieve relative path resolution in `svg-stylus` as a result  (#1).

However, if instead of relying on `svg-stylus` to resolve the provided path and read the file, we use the Stylus built-in function `embedurl()` to read in the file (resolving the path against Stylus `paths` as well as relative to the calling file) we'll be able to get the data we need within `svg-stylus` (albeit base64 encoded and wrapped in a `url(data:image/svg+xml;base64,)` bit.

This would result in the following usage:

```
.checkbox-checkmark {
  background-image: svgurl(embedurl('embed/Checkbox.svg')) svg(path fill blue);
}
```

It's definitely not as pretty, but it does get the job done without having to guess about where paths will be resolved against.

Additionally, though this is a bit of a silly use case, this PR will enable users to process an existing `url(data:)` string if they have pasted it into their Stylus file:

```
.checkbox-checkmark {
  background-image: svgurl(url('data:image/svg+xml;base64,...')) svg(path fill blue);
}
```

Note that this PR does not remove the ability to provide a path relative to the project root (current behavior), both usages still work.