### PR TITLE
Allow multiple embeds fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ background-image: svgurl('./img/icon.svg') svg(path$p1 fill #00FF00, path$p2 fil
 ```
 
 ---
+#### Multiple images
+```css
+background-image: svgurl('./img/icon.svg') svg(rect fill #FF0000), svgurl('./img/othericon.svg') svg(rect fill #0000FF);
+```
+
+---
 
 #### Resolving a relative path
 

--- a/svg.js
+++ b/svg.js
@@ -9,7 +9,7 @@ var _config = {};
 
 
 var SVG_PATTERN = new RegExp(
-  '(^|\\s)' +
+  '(\\s?)' +
     // url(...)
     '(?:svgurl\\((.*?)\\))' + '\\s+' +
     // svg(...)
@@ -199,7 +199,11 @@ function parseDeclaration(declaration) {
   if (!declaration || declaration.property !== 'background-image') {
     return;
   }
-  declaration.value = declaration.value.replace(SVG_PATTERN, replaceDeclarationValue);
+
+  // allows multiple background images
+  while (SVG_PATTERN.test(declaration.value)) {
+    declaration.value = declaration.value.replace(SVG_PATTERN, replaceDeclarationValue);
+  }
 }
 
 

--- a/test/style.styl
+++ b/test/style.styl
@@ -13,3 +13,6 @@ div
 
 .test4
     background-image: svgurl(embedurl('./icon.svg')) svg(rect fill #FF0000)
+
+.test5
+    background-image: svgurl('icon.svg') svg(rect fill #F00), svgurl('icon.svg') svg(rect fill #00F);


### PR DESCRIPTION
- Modified SVG pattern to allow finding a svgurl statement that is not at the beginning of the style declaration.
- Updated parseDeclaration to replace all svgurl usages instead of just the first one.
- Added related test.
